### PR TITLE
Call declare_namespace in __init__.py

### DIFF
--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Without this, the following error occurs when running
pip install sphinxcontrib-japanese-text-join

```
error: Namespace package problem: sphinxcontrib is a namespace
package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
```

The fix for this error is written at
https://packaging.python.org/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages